### PR TITLE
Fix a merge conflict introduced in c303e32

### DIFF
--- a/plugin/vimreddit.py
+++ b/plugin/vimreddit.py
@@ -44,13 +44,9 @@ def vim_reddit(sub):
     vim.command('setlocal noswapfile')
     vim.command('setlocal buftype=nofile')
 
-<<<<<<< HEAD
-    bufwrite('/r/' + sub + ' ' + '(http://www.reddit.com/r/' + sub + ')')
-=======
     bufwrite('    ┌─o')
     bufwrite(' ((•  •))  r e d d i t')
     bufwrite(' http://www.reddit.com/r/' + sub)
->>>>>>> b08fbd990f6f4d3a201d2f7d3cd3381e36788573
     bufwrite('')
 
     items = json.loads(urllib2.urlopen(redditurl(sub)).read())


### PR DESCRIPTION
Remove the merge conflict lines to let the plugin run again.  I think this fix leaves the intended lines.
