### PR TITLE
Makes mappings local to reddit buffers

### DIFF
--- a/ftplugin/reddit.vim
+++ b/ftplugin/reddit.vim
@@ -1,2 +1,2 @@
-noremap o :python vim_reddit_link()<cr>
-noremap O :python vim_reddit_link(in_browser=True)<cr>
+noremap <buffer> o :python vim_reddit_link()<cr>
+noremap <buffer> O :python vim_reddit_link(in_browser=True)<cr>


### PR DESCRIPTION
After reading some reddits, o and O keep remapped to`vim_reddit_link` python calls. That's very annoying for people like me that uses those mapping often.  This commit make those mappings local to  reddit buffers.
