### PR TITLE
Add custom user-agent: "Python/vim-reddit"

### DIFF
--- a/plugin/vimreddit.py
+++ b/plugin/vimreddit.py
@@ -49,7 +49,9 @@ def vim_reddit(sub):
     bufwrite(' http://www.reddit.com/r/' + sub)
     bufwrite('')
 
-    items = json.loads(urllib2.urlopen(redditurl(sub)).read())
+    opener = urllib2.build_opener()
+    opener.addheaders = [('User-Agent', 'Python/vim-reddit')]
+    items = json.loads(opener.open(redditurl(sub)).read())
     for i, item in enumerate(items['data']['children']):
         item = item['data']
         try:


### PR DESCRIPTION
According to https://github.com/reddit/reddit/wiki/API

> Many default User-Agents (like "Python/urllib" or "Java") are drastically limited to encourage unique and descriptive user-agent strings.

This changes the User-Agent to a more descriptive one: "Python/vim-reddit"

Fixes #3 